### PR TITLE
Export saveProjectToServer & add support for extra HTTP headers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import {ScratchPaintReducer} from 'scratch-paint';
 import {setFullScreen, setPlayer} from './reducers/mode';
 import {remixProject} from './reducers/project-state';
 import {setAppElement} from 'react-modal';
+import saveProjectToServer from './lib/save-project-to-server';
 
 const guiReducers = {
     locales: LocalesReducer,
@@ -27,5 +28,6 @@ export {
     localesInitialState,
     remixProject,
     setFullScreen,
-    setPlayer
+    setPlayer,
+    saveProjectToServer
 };

--- a/src/lib/save-project-to-server.js
+++ b/src/lib/save-project-to-server.js
@@ -12,15 +12,14 @@ import storage from '../lib/storage';
  * @property {?boolean} params.isCopy a flag indicating if this save is creating a copy.
  * @property {?boolean} params.isRemix a flag indicating if this save is creating a remix.
  * @property {?string} params.title the title of the project.
+ * @param {object} headers extra HTTP request headers.
  * @return {Promise} A promise that resolves when the network request resolves.
  */
-export default function (projectId, vmState, params) {
+export default function (projectId, vmState, params, headers) {
     const opts = {
         body: vmState,
         // If we set json:true then the body is double-stringified, so don't
-        headers: {
-            'Content-Type': 'application/json'
-        },
+        headers: Object.assign({'Content-Type': 'application/json'}, headers),
         withCredentials: true
     };
     const creatingProject = projectId === null || typeof projectId === 'undefined';


### PR DESCRIPTION
I want to be able to send an `X-CSRF-Token` HTTP header when sending a
`POST` or `PUT` request to create or update the project.

* Exporting `saveProjectToServer` means that I can set the
`onUpdateProjectData` property to a function which wraps
`saveProjectToServer`.

* Adding the optional headers parameter to the `saveProjectToServer`
function means that the wrapping function can pass in extra HTTP headers
to be sent in any request.
