### PR TITLE
Fix nav images alt

### DIFF
--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -259,7 +259,7 @@ const GUIComponent = props => {
                                         <img
                                             draggable={false}
                                             src={codeIcon}
-                                            alt={"Code icon"}
+                                            alt={'Code icon'}
                                         />
                                         <FormattedMessage
                                             defaultMessage="Code"
@@ -274,7 +274,7 @@ const GUIComponent = props => {
                                         <img
                                             draggable={false}
                                             src={costumesIcon}
-                                            alt={"Costumes icon"}
+                                            alt={'Costumes icon'}
                                         />
                                         {targetIsStage ? (
                                             <FormattedMessage
@@ -297,7 +297,7 @@ const GUIComponent = props => {
                                         <img
                                             draggable={false}
                                             src={soundsIcon}
-                                            alt={"Sounds icon"}
+                                            alt={'Sounds icon'}
                                         />
                                         <FormattedMessage
                                             defaultMessage="Sounds"
@@ -329,7 +329,7 @@ const GUIComponent = props => {
                                                 className={styles.extensionButtonIcon}
                                                 draggable={false}
                                                 src={addExtensionIcon}
-                                                alt={"Add extension icon"}
+                                                alt={'Add extension icon'}
                                             />
                                         </button>
                                     </Box>

--- a/src/components/gui/gui.jsx
+++ b/src/components/gui/gui.jsx
@@ -259,6 +259,7 @@ const GUIComponent = props => {
                                         <img
                                             draggable={false}
                                             src={codeIcon}
+                                            alt={"Code icon"}
                                         />
                                         <FormattedMessage
                                             defaultMessage="Code"
@@ -273,6 +274,7 @@ const GUIComponent = props => {
                                         <img
                                             draggable={false}
                                             src={costumesIcon}
+                                            alt={"Costumes icon"}
                                         />
                                         {targetIsStage ? (
                                             <FormattedMessage
@@ -295,6 +297,7 @@ const GUIComponent = props => {
                                         <img
                                             draggable={false}
                                             src={soundsIcon}
+                                            alt={"Sounds icon"}
                                         />
                                         <FormattedMessage
                                             defaultMessage="Sounds"
@@ -326,6 +329,7 @@ const GUIComponent = props => {
                                                 className={styles.extensionButtonIcon}
                                                 draggable={false}
                                                 src={addExtensionIcon}
+                                                alt={"Add extension icon"}
                                             />
                                         </button>
                                     </Box>


### PR DESCRIPTION
### Resolves

Top left navigation is lacking basic accessibility features like `alt=''`. Screen readers are losing a context of a tab they should be opening. 

### Proposed Changes

Provided alt description for the tabs: Code, Costumes, and Sounds.

<img width="1049" alt="Screenshot 2023-06-01 at 09 53 48" src="https://github.com/RaspberryPiFoundation/scratch-gui/assets/8046557/d06b62c1-01ce-4e5e-9bcd-a4fe6b99b41b">


### Further reading
https://dequeuniversity.com/rules/axe/4.7/image-alt?application=AxeChrome 




